### PR TITLE
Add an expiry to links created on Seafile server

### DIFF
--- a/cloudfile-seafile@oregpreshaz.eu/chrome/content/management.js
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/content/management.js
@@ -14,6 +14,12 @@ function onLoadProvider(provider) {
   let unknownSize = bundle.GetStringFromName("attachmentSizeUnknown");
   let repoName = document.getElementById("repo-name");
   repoName.textContent = provider.serviceURL;
+  let defaultExpiry = document.getElementById("default-expiry");
+
+  let _accountKey = provider.accountKey;
+  let _prefBranch = Services.prefs.getBranch("mail.cloud_files.accounts." + _accountKey + ".");
+  defaultExpiry.textContent = _prefBranch.getIntPref("expiry");
+
   let fileSpaceUsed = document.getElementById("file-space-used");
   fileSpaceUsed.textContent = messenger.formatFileSize(provider.fileSpaceUsed);
   let fileSpaceUsedSwatch = document.getElementById("file-space-used-swatch");

--- a/cloudfile-seafile@oregpreshaz.eu/chrome/content/management.xhtml
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/content/management.xhtml
@@ -8,6 +8,7 @@
 <!DOCTYPE html [
   <!ENTITY % htmlDTD PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "DTD/xhtml1-strict.dtd"> %htmlDTD;
   <!ENTITY % managementDTD SYSTEM "chrome://messenger/locale/cloudfile/management.dtd"> %managementDTD;
+  <!ENTITY % seafileDTD SYSTEM "chrome://cloudfile-seafile/locale/settings.dtd"> %seafileDTD;
 ]>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
@@ -26,6 +27,11 @@
       <div id="provider-name">
       <h1>SeaFile</h1>
       <h2 id="repo-name"></h2>
+      <div>
+        <label>&SeaFileSettings.defaultExpiry;</label>
+        <span id="default-expiry"/>
+        <span>&SeaFileSettings.defaultExpiryUnit;</span>
+      </div>
       </div>
     </div>
 

--- a/cloudfile-seafile@oregpreshaz.eu/chrome/content/settings.js
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/content/settings.js
@@ -12,11 +12,13 @@ function extraArgs() {
     baseURL += "/";
   }
   var libraryValue = document.getElementById("library").value.trim();
+  var expiryValue = document.getElementById("expiry").value.trim();
   var libraryCreate = document.getElementById("create_lib_if_not_found").checked;
   return {
     "baseURL": { type: "char", value: baseURL },
     "username": { type: "char", value: usernameValue },
     "library": { type: "char", value: libraryValue },
+    "expiry": { type: "int", value: expiryValue },
     "libraryCreate": { type: "bool", value: libraryCreate },
   };  
 }

--- a/cloudfile-seafile@oregpreshaz.eu/chrome/content/settings.xhtml
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/content/settings.xhtml
@@ -28,9 +28,14 @@
       <input id="library" type="text" required="true" value="ThunderbirdFilelink" />
 
       <label>&SeaFileSettings.description;</label>
-      
+
+      <label for="expiry">&SeaFileSettings.expiry;</label>
+      <input id="expiry" type="text" pattern="[1-9][0-9]*" required="true" value="31" />
+
       <label for="create_lib_if_not_found">&SeaFileSettings.create_lib_if_not_found;</label>
       <input id="create_lib_if_not_found" type="checkbox" checked="checked"/>
+
+      <br />
 
     </form>
   </body>

--- a/cloudfile-seafile@oregpreshaz.eu/chrome/locales/en-US/settings.dtd
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/locales/en-US/settings.dtd
@@ -6,5 +6,8 @@
 <!ENTITY SeaFileSettings.baseURL "Service Location (e.g. https://seafile.example.com/)">
 <!ENTITY SeaFileSettings.username "Username">
 <!ENTITY SeaFileSettings.library "Library">
+<!ENTITY SeaFileSettings.expiry "Expire links after (1~365 days)">
+<!ENTITY SeaFileSettings.defaultExpiry "Links will expire after">
+<!ENTITY SeaFileSettings.defaultExpiryUnit "days">
 <!ENTITY SeaFileSettings.create_lib_if_not_found "Create library if not found?">
 <!ENTITY SeaFileSettings.description "Use a library without encryption. Files will be uploaded under /apps/mozilla_thunderbird directory in the library.">

--- a/cloudfile-seafile@oregpreshaz.eu/chrome/locales/fr-FR/settings.dtd
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/locales/fr-FR/settings.dtd
@@ -6,5 +6,8 @@
 <!ENTITY SeaFileSettings.baseURL "Adresse du service (par exemple: https://seafile.site.com/)">
 <!ENTITY SeaFileSettings.username "Utilisateur">
 <!ENTITY SeaFileSettings.library "Bibliothèque">
+<!ENTITY SeaFileSettings.expiry "Expiration des liens (1~365 jours)">
+<!ENTITY SeaFileSettings.defaultExpiry "Les liens expirent après">
+<!ENTITY SeaFileSettings.defaultExpiryUnit "jours">
 <!ENTITY SeaFileSettings.create_lib_if_not_found "Créer la bibliothèque si non trouvée ?">
 <!ENTITY SeaFileSettings.description "Utiliser une bibliothèque sans chiffrement. Les fichiers seront envoyés dans /apps/mozilla_thunderbird dans la bibliothèque.">

--- a/cloudfile-seafile@oregpreshaz.eu/chrome/locales/hu/settings.dtd
+++ b/cloudfile-seafile@oregpreshaz.eu/chrome/locales/hu/settings.dtd
@@ -6,5 +6,8 @@
 <!ENTITY SeaFileSettings.baseURL "SeaFile szerver URL (pl.: https://seafile.example.com/)">
 <!ENTITY SeaFileSettings.username "Felhasználói név">
 <!ENTITY SeaFileSettings.library "Kötet">
+<!ENTITY SeaFileSettings.expiry "Expire links after (1~365 days)">
+<!ENTITY SeaFileSettings.defaultExpiry "Links will expire after">
+<!ENTITY SeaFileSettings.defaultExpiryUnit "days">
 <!ENTITY SeaFileSettings.create_lib_if_not_found "Létrehozza a kötetet ha nincs?">
 <!ENTITY SeaFileSettings.description "Olyan Kötetet kell megadni ami nem titkosított. A kötet főkönyvárába a /apps/mozilla_thunderbird könyvtár alá kerülnek a feltöltött fájlok.">


### PR DESCRIPTION
Expiration can be configured upon setting up the filelink account, and must be a number between 1 and 365 days.