### PR TITLE
add timestamp in file name

### DIFF
--- a/cloudfile-seafile@oregpreshaz.eu/components/nsSeaFile.js
+++ b/cloudfile-seafile@oregpreshaz.eu/components/nsSeaFile.js
@@ -23,6 +23,7 @@ var gServerUrl = "";
 var kAuthPath = "api2/auth-token/";
 var kUserInfoPath = "api2/account/info/";
 var kRepoPath = "api2/repos/";
+var TS = Date.now();
 
 function nsSeaFile() {
   this.log = Log4Moz.getConfiguredLogger("SeaFile","DEBUG","DEBUG");
@@ -1149,7 +1150,7 @@ nsSeaFileFileUploader.prototype = {
     //let fileName = /^[\040-\176]+$/.test(this.file.leafName)
     //    ? this.file.leafName
     //    : encodeURIComponent(this.file.leafName);
-    let fileName = this.file.leafName;
+    let fileName = TS+'_'+this.file.leafName;
     let fileContents = "--" + boundary +
       "\r\nContent-Disposition: form-data; name=\"parent_dir\"\r\n\r\n"+
       this.folderName+"\r\n"+
@@ -1285,7 +1286,7 @@ nsSeaFileFileUploader.prototype = {
     //              ? this.file.leafName
     //              : encodeURIComponent(this.file.leafName);
     let fileName = this.file.leafName;
-    req.send("p="+this.folderName+"/"+fileName);
+    req.send("p="+this.folderName+"/"+TS+'_'+fileName);
   },
 
   /**


### PR DESCRIPTION
Add unique timestamp in uploaded filename and download link:
Sometimes filename collides with previous uploaded file, means you send bad link or with complex filename, thundebird suggests a generic name like nsmail.[extension], which collides a lot.